### PR TITLE
Adding shortlink 'hulunet'

### DIFF
--- a/apps/SE task/HuluNet+/metadata.json
+++ b/apps/SE task/HuluNet+/metadata.json
@@ -31,7 +31,7 @@
       }
     },
     "rootScreen": "home",
-    "shortlink": "hulu",
+    "shortlink": "hulunet",
     "version": "3.146.0",
     "experimentalDataTabEnabled": true
   }


### PR DESCRIPTION
### Adding shortlink 'hulunet'

This PR adds the shortlink 'hulunet' to the Retool Source Control repository.
